### PR TITLE
Update cloudfire / fix preg_match()

### DIFF
--- a/cloudflare.php
+++ b/cloudflare.php
@@ -33,7 +33,7 @@ class CloudFlare {
         if (!empty($body)) {
             $this->addBody($body);
         }
-        return (preg_match('/\<title\>Please wait 5 seconds\.\.\.\<\/title\>/', $this->body_one_line));
+        return (preg_match('/5 seconds/', $this->body_one_line));
     }
     
     public function addBody($body) {


### PR DESCRIPTION
Update cloudfire / fix preg_match(). Cloudflare not giving title anymore, so you need to look for "5 seconds" text in body